### PR TITLE
Parse day id from javascript string

### DIFF
--- a/lib/Eetlijst.js
+++ b/lib/Eetlijst.js
@@ -76,6 +76,9 @@ class Eetlijst {
 				if( typeof day === 'undefined' )
 					day = summary.days[0].id;
 
+				if( day.includes('javascript:k(') )
+					day = day.replace('javascript:k(', '').split(',')[0];
+
 				let body = querystring.stringify({
 					'session_id'		: this._sessionId,
 					'day[]'				: day,


### PR DESCRIPTION
This fixes setUserState on some Eetlijst accounts. For my Eetlijst account the `summary.days` object contains objects as follows:

```
  { id: 'javascript:k(1506636000,0,1',
    date: 'vr 29-9',
    deadline: '',
    users:
     { User1: 'eat',
       User2: 'absent',
       User3: 'unknown',
       User4: 'unknown',
       User5: 'unknown',
      User6: 'unknown' },
    totals: { unknown: 4, absent: 1, eat: 1, cook: 0 } },
```

Hence the setUserState fails as the id is not valid for some reason, now the id string gets parsed correctly if this javascript stuff is in it.